### PR TITLE
Implement VGG-16 and VGG-19 networks

### DIFF
--- a/gradus/networks/__init__.py
+++ b/gradus/networks/__init__.py
@@ -18,8 +18,13 @@ __all__ =   [
                 # Blocks
                 "ResNetBlock",
                 "ResNetBottleneck",
+
+                # VGG
+                "VGG16",
+                "VGG19",
             ]
 
 from gradus.networks.autoencoder    import Autoencoder
 from gradus.networks.cnn            import CNN
 from gradus.networks.resnet         import *
+from gradus.networks.vgg            import *

--- a/gradus/networks/vgg/__base__.py
+++ b/gradus/networks/vgg/__base__.py
@@ -5,28 +5,21 @@ VGG (Visual Geometry Group) network protocol.
 
 __all__ = ["VGG"]
 
-from logging                    import Logger
-from typing                     import List, Tuple, Union
+from logging            import Logger
+from typing             import List, Tuple, Union
 
-from torch                      import flatten, Tensor
-from torch.nn                   import AdaptiveAvgPool2d, BatchNorm2d, Conv2d, Dropout, Linear, \
-                                       MaxPool2d, Module, ReLU, Sequential
-from torch.nn.init              import constant_, kaiming_normal_, normal_
+from torch              import flatten, Tensor
+from torch.nn           import AdaptiveAvgPool2d, BatchNorm2d, Conv2d, Dropout, Linear, MaxPool2d, \
+                               Module, ReLU, Sequential
+from torch.nn.init      import constant_, kaiming_normal_, normal_
 
-from gradus.utilities           import get_logger
-
-# VGG architecture configurations (from Table 1 of the VGG paper).
-# Numbers represent Conv2d output channels; 'M' represents MaxPool2d.
-VGG_CONFIGS: dict = {
-    "D": [64, 64, "M", 128, 128, "M", 256, 256, 256, "M", 512, 512, 512, "M", 512, 512, 512, "M"],
-    "E": [64, 64, "M", 128, 128, "M", 256, 256, 256, 256, "M", 512, 512, 512, 512, "M", 512, 512, 512, 512, "M"],
-}
+from gradus.utilities   import get_logger
 
 class VGG(Module):
     """# VGG Neural Network"""
 
     def __init__(self,
-        config:         str,
+        layer_config:   List[Union[int, str]],
         input_shape:    Tuple[int, ...],
         num_classes:    int,
         batch_norm:     bool =              True
@@ -34,10 +27,10 @@ class VGG(Module):
         """# Instantiate VGG Neural Network.
 
         ## Args:
-            * config        (str):          VGG configuration key ("D" for VGG-16, "E" for VGG-19).
-            * input_shape   (Tuple[int]):   Shape of input samples.
-            * num_classes   (int):          Number of classes (output logits).
-            * batch_norm    (bool):         Use batch normalization. Defaults to True.
+            * config        (List[int | str]):  VGG layer configuration.
+            * input_shape   (Tuple[int]):       Shape of input samples.
+            * num_classes   (int):              Number of classes (output logits).
+            * batch_norm    (bool):             Use batch normalization. Defaults to True.
         """
         # Initialize module.
         super(VGG, self).__init__()
@@ -47,15 +40,13 @@ class VGG(Module):
 
         # Build feature extraction layers.
         self._features_:    Sequential =        self._make_layers_(
-                                                    config =        VGG_CONFIGS[config],
+                                                    config =        layer_config,
                                                     in_channels =   input_shape[0],
                                                     batch_norm =    batch_norm
                                                 )
 
         # Adaptive pooling to fixed spatial size.
-        self._avg_pool_:    AdaptiveAvgPool2d = AdaptiveAvgPool2d(
-                                                    output_size =   (7, 7)
-                                                )
+        self._avg_pool_:    AdaptiveAvgPool2d = AdaptiveAvgPool2d(output_size = (7, 7))
 
         # Classification layers.
         self._classifier_:  Sequential =        Sequential(
@@ -147,12 +138,12 @@ class VGG(Module):
         """# Build VGG Feature Extraction Layers.
 
         ## Args:
-            * config        (List):     Layer configuration list.
-            * in_channels   (int):      Number of input channels.
-            * batch_norm    (bool):     Use batch normalization. Defaults to True.
+            * config        (List): Layer configuration list.
+            * in_channels   (int):  Number of input channels.
+            * batch_norm    (bool): Use batch normalization. Defaults to True.
 
         ## Returns:
-            Sequential: Feature extraction layers.
+            * Sequential:   Feature extraction layers.
         """
         # Initialize list of layers.
         layers: List[Module] = []
@@ -164,12 +155,7 @@ class VGG(Module):
             if v == "M":
 
                 # Add max pooling layer.
-                layers.append(
-                    MaxPool2d(
-                        kernel_size =   2,
-                        stride =        2
-                    )
-                )
+                layers.append(MaxPool2d(kernel_size = 2, stride = 2))
 
             # Otherwise (convolutional layer)...
             else:

--- a/gradus/networks/vgg/__base__.py
+++ b/gradus/networks/vgg/__base__.py
@@ -1,0 +1,200 @@
+"""# gradus.networks.vgg.base
+
+VGG (Visual Geometry Group) network protocol.
+"""
+
+__all__ = ["VGG"]
+
+from logging                    import Logger
+from typing                     import List, Tuple, Union
+
+from torch                      import flatten, Tensor
+from torch.nn                   import AdaptiveAvgPool2d, BatchNorm2d, Conv2d, Dropout, Linear, \
+                                       MaxPool2d, Module, ReLU, Sequential
+from torch.nn.init              import constant_, kaiming_normal_, normal_
+
+from gradus.utilities           import get_logger
+
+# VGG architecture configurations (from Table 1 of the VGG paper).
+# Numbers represent Conv2d output channels; 'M' represents MaxPool2d.
+VGG_CONFIGS: dict = {
+    "D": [64, 64, "M", 128, 128, "M", 256, 256, 256, "M", 512, 512, 512, "M", 512, 512, 512, "M"],
+    "E": [64, 64, "M", 128, 128, "M", 256, 256, 256, 256, "M", 512, 512, 512, 512, "M", 512, 512, 512, 512, "M"],
+}
+
+class VGG(Module):
+    """# VGG Neural Network"""
+
+    def __init__(self,
+        config:         str,
+        input_shape:    Tuple[int, ...],
+        num_classes:    int,
+        batch_norm:     bool =              True
+    ):
+        """# Instantiate VGG Neural Network.
+
+        ## Args:
+            * config        (str):          VGG configuration key ("D" for VGG-16, "E" for VGG-19).
+            * input_shape   (Tuple[int]):   Shape of input samples.
+            * num_classes   (int):          Number of classes (output logits).
+            * batch_norm    (bool):         Use batch normalization. Defaults to True.
+        """
+        # Initialize module.
+        super(VGG, self).__init__()
+
+        # Initialize logger.
+        self.__logger__:    Logger =            get_logger("vgg")
+
+        # Build feature extraction layers.
+        self._features_:    Sequential =        self._make_layers_(
+                                                    config =        VGG_CONFIGS[config],
+                                                    in_channels =   input_shape[0],
+                                                    batch_norm =    batch_norm
+                                                )
+
+        # Adaptive pooling to fixed spatial size.
+        self._avg_pool_:    AdaptiveAvgPool2d = AdaptiveAvgPool2d(
+                                                    output_size =   (7, 7)
+                                                )
+
+        # Classification layers.
+        self._classifier_:  Sequential =        Sequential(
+                                                    Linear(
+                                                        in_features =   512 * 7 * 7,
+                                                        out_features =  4096
+                                                    ),
+                                                    ReLU(inplace = True),
+                                                    Dropout(p = 0.5),
+                                                    Linear(
+                                                        in_features =   4096,
+                                                        out_features =  4096
+                                                    ),
+                                                    ReLU(inplace = True),
+                                                    Dropout(p = 0.5),
+                                                    Linear(
+                                                        in_features =   4096,
+                                                        out_features =  num_classes
+                                                    ),
+                                                )
+
+        # Initialize weights.
+        self._initialize_weights_()
+
+    # METHODS ======================================================================================
+
+    def forward(self,
+        X:  Tensor
+    ) -> Tensor:
+        """# Forward Pass Through Network.
+
+        ## Args:
+            * X (Tensor):   Input tensor.
+
+        ## Returns:
+            * Tensor:   Output tensor.
+        """
+        # Feature extraction.
+        X_1:    Tensor =    self._features_(X)
+
+        # Adaptive average pooling.
+        X_2:    Tensor =    self._avg_pool_(X_1)
+
+        # Flatten.
+        X_3:    Tensor =    flatten(input = X_2, start_dim = 1)
+
+        # Classification.
+        return self._classifier_(X_3)
+
+    # HELPERS ======================================================================================
+
+    def _initialize_weights_(self) -> None:
+        """# Initialize Weights."""
+        # For each module in network...
+        for m in self.modules():
+
+            # If convolving layer...
+            if isinstance(m, Conv2d):
+
+                # Initialize with Kaiming normal distribution.
+                kaiming_normal_(tensor = m.weight, mode = "fan_out", nonlinearity = "relu")
+
+                # If bias exists...
+                if m.bias is not None:
+
+                    # Initialize bias to zero.
+                    constant_(tensor = m.bias, val = 0)
+
+            # If batch normalization layer...
+            elif isinstance(m, BatchNorm2d):
+
+                # Initialize weights to 1 and biases to 0.
+                constant_(tensor = m.weight, val = 1)
+                constant_(tensor = m.bias,   val = 0)
+
+            # If fully connected layer...
+            elif isinstance(m, Linear):
+
+                # Initialize with normal distribution.
+                normal_(tensor = m.weight, mean = 0, std = 0.01)
+                constant_(tensor = m.bias, val = 0)
+
+    @staticmethod
+    def _make_layers_(
+        config:         List[Union[int, str]],
+        in_channels:    int,
+        batch_norm:     bool =                  True
+    ) -> Sequential:
+        """# Build VGG Feature Extraction Layers.
+
+        ## Args:
+            * config        (List):     Layer configuration list.
+            * in_channels   (int):      Number of input channels.
+            * batch_norm    (bool):     Use batch normalization. Defaults to True.
+
+        ## Returns:
+            Sequential: Feature extraction layers.
+        """
+        # Initialize list of layers.
+        layers: List[Module] = []
+
+        # For each entry in configuration...
+        for v in config:
+
+            # If max pooling marker...
+            if v == "M":
+
+                # Add max pooling layer.
+                layers.append(
+                    MaxPool2d(
+                        kernel_size =   2,
+                        stride =        2
+                    )
+                )
+
+            # Otherwise (convolutional layer)...
+            else:
+
+                # Add convolving layer.
+                layers.append(
+                    Conv2d(
+                        in_channels =   in_channels,
+                        out_channels =  v,
+                        kernel_size =   3,
+                        padding =       1
+                    )
+                )
+
+                # If batch normalization is enabled...
+                if batch_norm:
+
+                    # Add batch normalization layer.
+                    layers.append(BatchNorm2d(num_features = v))
+
+                # Add activation.
+                layers.append(ReLU(inplace = True))
+
+                # Update channel count.
+                in_channels = v
+
+        # Provide feature extraction layers.
+        return Sequential(*layers)

--- a/gradus/networks/vgg/__init__.py
+++ b/gradus/networks/vgg/__init__.py
@@ -1,0 +1,13 @@
+"""# gradus.networks.vgg
+
+VGG (Visual Geometry Group) network architectures.
+"""
+
+__all__ =   [
+                # Networks
+                "VGG16",
+                "VGG19",
+            ]
+
+from gradus.networks.vgg.vgg_16   import VGG16
+from gradus.networks.vgg.vgg_19   import VGG19

--- a/gradus/networks/vgg/vgg_16/__args__.py
+++ b/gradus/networks/vgg/vgg_16/__args__.py
@@ -1,0 +1,18 @@
+"""# gradus.networks.vgg.vgg_16
+
+Argument definitions & parsing for 16-layer VGG network.
+"""
+
+__all__ = ["VGG16Config"]
+
+from gradus.configuration   import NetworkConfig
+
+class VGG16Config(NetworkConfig):
+    """# VGG-16 Network Configuration"""
+
+    def __init__(self):
+        """# Instantiate VGG-16 Network Configuration."""
+        super(VGG16Config, self).__init__(
+            name =  "vgg-16",
+            help =  """VGG neural network with 16 learnable layers."""
+        )

--- a/gradus/networks/vgg/vgg_16/__base__.py
+++ b/gradus/networks/vgg/vgg_16/__base__.py
@@ -1,0 +1,40 @@
+"""# gradus.networks.vgg.vgg_16
+
+VGG-16 neural network implementation.
+"""
+
+__all__ = ["VGG16"]
+
+from typing                                     import Tuple
+
+from gradus.networks.vgg.__base__              import VGG
+from gradus.networks.vgg.vgg_16.__args__       import VGG16Config
+from gradus.registration                        import register_network
+
+@register_network(
+    id =        "vgg-16",
+    config =    VGG16Config,
+    tags =      ["vgg", "cnn", "16-layers"]
+)
+class VGG16(VGG):
+    """# 16-Layer VGG Neural Network"""
+
+    def __init__(self,
+        input_shape:    Tuple[int, ...],
+        num_classes:    int,
+        batch_norm:     bool =              True
+    ):
+        """# Instantiate VGG-16 Neural Network.
+
+        ## Args:
+            * input_shape   (Tuple[int]):   Shape of input samples.
+            * num_classes   (int):          Number of classes (output logits).
+            * batch_norm    (bool):         Use batch normalization. Defaults to True.
+        """
+        # Initialize network.
+        super(VGG16, self).__init__(
+            config =        "D",
+            input_shape =   input_shape,
+            num_classes =   num_classes,
+            batch_norm =    batch_norm
+        )

--- a/gradus/networks/vgg/vgg_16/__base__.py
+++ b/gradus/networks/vgg/vgg_16/__base__.py
@@ -5,11 +5,11 @@ VGG-16 neural network implementation.
 
 __all__ = ["VGG16"]
 
-from typing                                     import Tuple
+from typing                                 import List, Tuple, Union
 
-from gradus.networks.vgg.__base__              import VGG
-from gradus.networks.vgg.vgg_16.__args__       import VGG16Config
-from gradus.registration                        import register_network
+from gradus.networks.vgg.__base__           import VGG
+from gradus.networks.vgg.vgg_16.__args__    import VGG16Config
+from gradus.registration                    import register_network
 
 @register_network(
     id =        "vgg-16",
@@ -32,9 +32,18 @@ class VGG16(VGG):
             * num_classes   (int):          Number of classes (output logits).
             * batch_norm    (bool):         Use batch normalization. Defaults to True.
         """
+        # Define layer config.
+        layer_config:   List[Union[int, str]] = [
+                                                    64,   64,      "M",
+                                                    128, 128,      "M",
+                                                    256, 256, 256, "M",
+                                                    512, 512, 512, "M",
+                                                    512, 512, 512, "M"
+                                                ]
+
         # Initialize network.
         super(VGG16, self).__init__(
-            config =        "D",
+            layer_config =  layer_config,
             input_shape =   input_shape,
             num_classes =   num_classes,
             batch_norm =    batch_norm

--- a/gradus/networks/vgg/vgg_16/__base__.py
+++ b/gradus/networks/vgg/vgg_16/__base__.py
@@ -22,7 +22,8 @@ class VGG16(VGG):
     def __init__(self,
         input_shape:    Tuple[int, ...],
         num_classes:    int,
-        batch_norm:     bool =              True
+        batch_norm:     bool =              True,
+        **kwargs
     ):
         """# Instantiate VGG-16 Neural Network.
 

--- a/gradus/networks/vgg/vgg_16/__init__.py
+++ b/gradus/networks/vgg/vgg_16/__init__.py
@@ -1,0 +1,8 @@
+"""# gradus.networks.vgg.vgg_16
+
+VGG Network (16 layers) module.
+"""
+
+__all__ = ["VGG16"]
+
+from gradus.networks.vgg.vgg_16.__base__  import VGG16

--- a/gradus/networks/vgg/vgg_16/__init__.py
+++ b/gradus/networks/vgg/vgg_16/__init__.py
@@ -5,4 +5,4 @@ VGG Network (16 layers) module.
 
 __all__ = ["VGG16"]
 
-from gradus.networks.vgg.vgg_16.__base__  import VGG16
+from gradus.networks.vgg.vgg_16.__base__    import VGG16

--- a/gradus/networks/vgg/vgg_19/__args__.py
+++ b/gradus/networks/vgg/vgg_19/__args__.py
@@ -1,0 +1,18 @@
+"""# gradus.networks.vgg.vgg_19
+
+Argument definitions & parsing for 19-layer VGG network.
+"""
+
+__all__ = ["VGG19Config"]
+
+from gradus.configuration   import NetworkConfig
+
+class VGG19Config(NetworkConfig):
+    """# VGG-19 Network Configuration"""
+
+    def __init__(self):
+        """# Instantiate VGG-19 Network Configuration."""
+        super(VGG19Config, self).__init__(
+            name =  "vgg-19",
+            help =  """VGG neural network with 19 learnable layers."""
+        )

--- a/gradus/networks/vgg/vgg_19/__base__.py
+++ b/gradus/networks/vgg/vgg_19/__base__.py
@@ -5,11 +5,11 @@ VGG-19 neural network implementation.
 
 __all__ = ["VGG19"]
 
-from typing                                     import Tuple
+from typing                                 import List, Tuple, Union
 
-from gradus.networks.vgg.__base__              import VGG
-from gradus.networks.vgg.vgg_19.__args__       import VGG19Config
-from gradus.registration                        import register_network
+from gradus.networks.vgg.__base__           import VGG
+from gradus.networks.vgg.vgg_19.__args__    import VGG19Config
+from gradus.registration                    import register_network
 
 @register_network(
     id =        "vgg-19",
@@ -32,9 +32,18 @@ class VGG19(VGG):
             * num_classes   (int):          Number of classes (output logits).
             * batch_norm    (bool):         Use batch normalization. Defaults to True.
         """
+        # Define layer config.
+        layer_config:   List[Union[int, str]] = [
+                                                    64,   64,           "M",
+                                                    128, 128,           "M",
+                                                    256, 256, 256, 256, "M",
+                                                    512, 512, 512, 512, "M",
+                                                    512, 512, 512, 512, "M"
+                                                ]
+
         # Initialize network.
         super(VGG19, self).__init__(
-            config =        "E",
+            layer_config =  layer_config,
             input_shape =   input_shape,
             num_classes =   num_classes,
             batch_norm =    batch_norm

--- a/gradus/networks/vgg/vgg_19/__base__.py
+++ b/gradus/networks/vgg/vgg_19/__base__.py
@@ -1,0 +1,40 @@
+"""# gradus.networks.vgg.vgg_19
+
+VGG-19 neural network implementation.
+"""
+
+__all__ = ["VGG19"]
+
+from typing                                     import Tuple
+
+from gradus.networks.vgg.__base__              import VGG
+from gradus.networks.vgg.vgg_19.__args__       import VGG19Config
+from gradus.registration                        import register_network
+
+@register_network(
+    id =        "vgg-19",
+    config =    VGG19Config,
+    tags =      ["vgg", "cnn", "19-layers"]
+)
+class VGG19(VGG):
+    """# 19-Layer VGG Neural Network"""
+
+    def __init__(self,
+        input_shape:    Tuple[int, ...],
+        num_classes:    int,
+        batch_norm:     bool =              True
+    ):
+        """# Instantiate VGG-19 Neural Network.
+
+        ## Args:
+            * input_shape   (Tuple[int]):   Shape of input samples.
+            * num_classes   (int):          Number of classes (output logits).
+            * batch_norm    (bool):         Use batch normalization. Defaults to True.
+        """
+        # Initialize network.
+        super(VGG19, self).__init__(
+            config =        "E",
+            input_shape =   input_shape,
+            num_classes =   num_classes,
+            batch_norm =    batch_norm
+        )

--- a/gradus/networks/vgg/vgg_19/__base__.py
+++ b/gradus/networks/vgg/vgg_19/__base__.py
@@ -22,7 +22,8 @@ class VGG19(VGG):
     def __init__(self,
         input_shape:    Tuple[int, ...],
         num_classes:    int,
-        batch_norm:     bool =              True
+        batch_norm:     bool =              True,
+        **kwargs
     ):
         """# Instantiate VGG-19 Neural Network.
 

--- a/gradus/networks/vgg/vgg_19/__init__.py
+++ b/gradus/networks/vgg/vgg_19/__init__.py
@@ -1,0 +1,8 @@
+"""# gradus.networks.vgg.vgg_19
+
+VGG Network (19 layers) module.
+"""
+
+__all__ = ["VGG19"]
+
+from gradus.networks.vgg.vgg_19.__base__  import VGG19

--- a/gradus/networks/vgg/vgg_19/__init__.py
+++ b/gradus/networks/vgg/vgg_19/__init__.py
@@ -5,4 +5,4 @@ VGG Network (19 layers) module.
 
 __all__ = ["VGG19"]
 
-from gradus.networks.vgg.vgg_19.__base__  import VGG19
+from gradus.networks.vgg.vgg_19.__base__    import VGG19


### PR DESCRIPTION
Adds VGG-16 and VGG-19 implementations following the existing ResNet pattern.

- VGG base class with configs D (VGG-16) and E (VGG-19) from the paper
- Batch normalization, Kaiming weight initialization, adaptive pooling
- Registered via the existing network registry system
- Tested with `gradus train vgg-16 cifar-10` and `gradus train vgg-19 cifar-10`