### PR TITLE
Register CvT-13 network and fix DSI metric

### DIFF
--- a/gradus/artifacts/train_record.py
+++ b/gradus/artifacts/train_record.py
@@ -87,6 +87,11 @@ class TrainingRecord():
                         row.get("hash") == self.hash
                         for row in DictReader(master_record)
                     )
+
+    @property
+    def batches_per_epoch(self) -> List[Optional[int]]:
+        """# Batches Processed at Each Recorded Epoch"""
+        return [e["batches"] for e in self._epochs_.values()]
         
     @property
     def best_accuracy(self) -> float:
@@ -140,21 +145,6 @@ class TrainingRecord():
 
         # Compute DSI: fraction of dataset processed, summed across epochs.
         return round(processed / self._max_batches_, 4)
-
-    @property
-    def batches_per_epoch(self) -> List[Optional[int]]:
-        """# Batches Processed at Each Recorded Epoch"""
-        return [e["batches"] for e in self._epochs_.values()]
-
-    @property
-    def max_batches(self) -> int:
-        """# Batches Available Per Epoch (Full Dataset Size)"""
-        return self._max_batches_
-
-    @property
-    def total_batches_processed(self) -> int:
-        """# Total Batches Processed Across All Epochs"""
-        return sum(b for b in self.batches_per_epoch if b is not None)
     
     @property
     def final_accuracy(self) -> float:
@@ -183,6 +173,11 @@ class TrainingRecord():
         return self._output_path_ / "master_record.csv"
 
     @property
+    def max_batches(self) -> int:
+        """# Batches Available Per Epoch (Full Dataset Size)"""
+        return self._max_batches_
+
+    @property
     def num_epochs(self) -> int:
         """# Quantity of Epochs Recorded"""
         return len(self._epochs_)
@@ -206,6 +201,11 @@ class TrainingRecord():
             "best_loss":        self.best_loss,
             "best_epoch":       self.best_epoch
         }
+
+    @property
+    def total_batches_processed(self) -> int:
+        """# Total Batches Processed Across All Epochs"""
+        return sum(b for b in self.batches_per_epoch if b is not None)
 
     @property
     def train_accuracies(self) -> List[float]:
@@ -287,17 +287,17 @@ class TrainingRecord():
 
         # Provide mapping of training data/results.
         return  {
-                    "best_epoch":           self.best_epoch,
-                    "best_val_accuracy":    self._epochs_[self.best_epoch]["validation"]["accuracy"],
-                    "final_train_accuracy": self.train_accuracies[-1],
-                    "final_train_loss":     self.train_losses[-1],
-                    "final_val_accuracy":   self.validation_accuracies[-1],
-                    "final_val_loss":       self.validation_losses[-1],
+                    "best_epoch":               self.best_epoch,
+                    "best_val_accuracy":        self._epochs_[self.best_epoch]["validation"]["accuracy"],
+                    "final_train_accuracy":     self.train_accuracies[-1],
+                    "final_train_loss":         self.train_losses[-1],
+                    "final_val_accuracy":       self.validation_accuracies[-1],
+                    "final_val_loss":           self.validation_losses[-1],
                     "dsi":                      self.dsi,
                     "max_batches_per_epoch":    self._max_batches_,
                     "total_batches_processed":  self.total_batches_processed,
                     "batches_per_epoch":        self.batches_per_epoch,
-                    "epochs":               self._epochs_,
+                    "epochs":                   self._epochs_,
                 }
     
     # HELPERS ======================================================================================
@@ -333,28 +333,28 @@ class TrainingRecord():
 
             # Write results to master record.
             DictWriter(master_record, fieldnames = FIELDS).writerow({
-                "network_id":           self._network_config_["id"],
-                "dataset_id":           self._dataset_config_["id"],
-                "epochs":               self._num_epochs_,
-                "seed":                 self._seed_,
-                "device":               self._device_,
-                "final_accuracy":       self.final_accuracy,
-                "final_loss":           self.final_loss,
-                "best_accuracy":        self.best_accuracy,
-                "best_loss":            self.best_loss,
-                "best_epoch":           self.best_epoch,
-                "shuffled":             self._dataset_config_["shuffled"],
-                "normalize_classes":    self._dataset_config_["normalize_classes"],
-                "rank":                 curriculum.get("rank"),
-                "metric":               curriculum.get("metric"),
-                "scope":                curriculum.get("scope"),
-                "schedule":             self._dataset_config_.get("schedule_id"),
-                "start_fraction":       self._dataset_config_.get("start_fraction"),
-                "dsi":                  self.dsi,
+                "network_id":               self._network_config_["id"],
+                "dataset_id":               self._dataset_config_["id"],
+                "epochs":                   self._num_epochs_,
+                "seed":                     self._seed_,
+                "device":                   self._device_,
+                "final_accuracy":           self.final_accuracy,
+                "final_loss":               self.final_loss,
+                "best_accuracy":            self.best_accuracy,
+                "best_loss":                self.best_loss,
+                "best_epoch":               self.best_epoch,
+                "shuffled":                 self._dataset_config_["shuffled"],
+                "normalize_classes":        self._dataset_config_["normalize_classes"],
+                "rank":                     curriculum.get("rank"),
+                "metric":                   curriculum.get("metric"),
+                "scope":                    curriculum.get("scope"),
+                "schedule":                 self._dataset_config_.get("schedule_id"),
+                "start_fraction":           self._dataset_config_.get("start_fraction"),
+                "dsi":                      self.dsi,
                 "max_batches_per_epoch":    self._max_batches_,
                 "total_batches_processed":  self.total_batches_processed,
-                "record_file":          self.record_path,
-                "hash":                 self.hash
+                "record_file":              self.record_path,
+                "hash":                     self.hash
             })
 
         # Communicate master record.
@@ -374,13 +374,13 @@ class TrainingRecord():
 
             # Save verbose training record.
             dump({
-                "config":   self.config,
-                "results":  self.results,
+                "config":                   self.config,
+                "results":                  self.results,
                 "dsi":                      self.dsi,
                 "max_batches_per_epoch":    self._max_batches_,
                 "total_batches_processed":  self.total_batches_processed,
                 "batches_per_epoch":        self.batches_per_epoch,
-                "epochs":   self._epochs_
+                "epochs":                   self._epochs_
             }, training_record, indent = 2, default = str)
 
         # Communicate verbose record path.

--- a/gradus/artifacts/train_record.py
+++ b/gradus/artifacts/train_record.py
@@ -119,10 +119,12 @@ class TrainingRecord():
     
     @property
     def dsi(self) -> Optional[float]:
-        """# Data Saving Index
+        """# Data Saturation Index
 
-        Fraction of total possible training data that was not processed, due to curriculum pacing. 
-        Returns None when no schedule was active (i.e., all epochs used full data).
+        Sum of the number of batches used at each epoch divided by the total number of batches in
+        the dataset (one-epoch size). For a baseline run using the full dataset every epoch, this
+        equals ``num_epochs``; curriculum runs that skip data score lower. Returns None when no
+        batch counts or max-batches reference is available.
         """
         # Extract recorded batch counts.
         batch_counts:   List[int] = [e["batches"] for e in self._epochs_.values()]
@@ -130,14 +132,29 @@ class TrainingRecord():
         # If no batch counts were recorded, DSI is not applicable.
         if not any(b is not None for b in batch_counts): return None
 
-        # Sum the number of batches processes.
+        # If per-epoch max-batches reference is unavailable, DSI is not applicable.
+        if not self._max_batches_: return None
+
+        # Sum the number of batches processed across all epochs.
         processed:      int =       sum(b for b in batch_counts if b is not None)
 
-        # Calculate the maximum number of epochs possible for training.
-        max_batches:    int =       self._max_batches_ * self._num_epochs_
+        # Compute DSI: fraction of dataset processed, summed across epochs.
+        return round(processed / self._max_batches_, 4)
 
-        # Compute DSI.
-        return round(1.0 - (processed / max_batches), 4)
+    @property
+    def batches_per_epoch(self) -> List[Optional[int]]:
+        """# Batches Processed at Each Recorded Epoch"""
+        return [e["batches"] for e in self._epochs_.values()]
+
+    @property
+    def max_batches(self) -> int:
+        """# Batches Available Per Epoch (Full Dataset Size)"""
+        return self._max_batches_
+
+    @property
+    def total_batches_processed(self) -> int:
+        """# Total Batches Processed Across All Epochs"""
+        return sum(b for b in self.batches_per_epoch if b is not None)
     
     @property
     def final_accuracy(self) -> float:
@@ -276,6 +293,10 @@ class TrainingRecord():
                     "final_train_loss":     self.train_losses[-1],
                     "final_val_accuracy":   self.validation_accuracies[-1],
                     "final_val_loss":       self.validation_losses[-1],
+                    "dsi":                      self.dsi,
+                    "max_batches_per_epoch":    self._max_batches_,
+                    "total_batches_processed":  self.total_batches_processed,
+                    "batches_per_epoch":        self.batches_per_epoch,
                     "epochs":               self._epochs_,
                 }
     
@@ -290,7 +311,9 @@ class TrainingRecord():
                                 "network_id", "dataset_id", "epochs", "seed", "device",
                                 "final_accuracy", "final_loss", "best_accuracy", "best_loss",
                                 "best_epoch", "shuffled", "normalize_classes", "rank", "metric",
-                                "scope", "schedule", "start_fraction", "dsi", "record_file", "hash"
+                                "scope", "schedule", "start_fraction", "dsi",
+                                "max_batches_per_epoch", "total_batches_processed",
+                                "record_file", "hash"
                             ]
         
         # If master record does not exist, or is empty...
@@ -328,6 +351,8 @@ class TrainingRecord():
                 "schedule":             self._dataset_config_.get("schedule_id"),
                 "start_fraction":       self._dataset_config_.get("start_fraction"),
                 "dsi":                  self.dsi,
+                "max_batches_per_epoch":    self._max_batches_,
+                "total_batches_processed":  self.total_batches_processed,
                 "record_file":          self.record_path,
                 "hash":                 self.hash
             })
@@ -351,6 +376,10 @@ class TrainingRecord():
             dump({
                 "config":   self.config,
                 "results":  self.results,
+                "dsi":                      self.dsi,
+                "max_batches_per_epoch":    self._max_batches_,
+                "total_batches_processed":  self.total_batches_processed,
+                "batches_per_epoch":        self.batches_per_epoch,
                 "epochs":   self._epochs_
             }, training_record, indent = 2, default = str)
 

--- a/gradus/networks/__init__.py
+++ b/gradus/networks/__init__.py
@@ -27,6 +27,9 @@ __all__ =   [
                 "VGG13",
                 "VGG16",
                 "VGG19",
+
+                # CvT
+                "CvT13",
             ]
 
 from gradus.networks.autoencoder    import Autoencoder
@@ -34,3 +37,4 @@ from gradus.networks.cnn            import CNN
 from gradus.networks.protocol       import Network
 from gradus.networks.resnet         import *
 from gradus.networks.vgg            import *
+from gradus.networks.cvt            import *

--- a/gradus/networks/__init__.py
+++ b/gradus/networks/__init__.py
@@ -34,7 +34,7 @@ __all__ =   [
 
 from gradus.networks.autoencoder    import Autoencoder
 from gradus.networks.cnn            import CNN
+from gradus.networks.cvt            import *
 from gradus.networks.protocol       import Network
 from gradus.networks.resnet         import *
 from gradus.networks.vgg            import *
-from gradus.networks.cvt            import *

--- a/gradus/networks/cvt/__base__.py
+++ b/gradus/networks/cvt/__base__.py
@@ -1,0 +1,171 @@
+"""# gradus.networks.cvt.__base__
+
+Shared Convolutional Vision Transformer (CvT) protocol.
+"""
+
+__all__ = ["CvT"]
+
+from typing     import List, Tuple
+
+from torch      import Tensor
+from torch.nn   import Conv2d, LayerNorm, Linear, Module, ModuleList
+from torch.nn.init  import constant_, trunc_normal_
+
+from gradus.networks.cvt.blocks     import CvTStage
+from gradus.networks.protocol       import Network
+
+
+class CvT(Network):
+    """# Convolutional Vision Transformer.
+
+    Three-stage hierarchical Transformer that replaces patch-embeddings
+    with convolutional token embeddings and the linear Q/K/V projections
+    with depth-wise separable convolutional projections.
+    """
+
+    def __init__(self,
+        id:                 str,
+        input_shape:        Tuple[int, ...],
+        num_classes:        int,
+        embed_dims:         List[int],
+        depths:             List[int],
+        num_heads:          List[int],
+        patch_sizes:        List[int],
+        patch_strides:      List[int],
+        patch_paddings:     List[int],
+        mlp_ratios:         List[float],
+        qkv_bias:           bool =          True,
+        drop_rate:          float =         0.0,
+        attn_drop_rate:     float =         0.0,
+        drop_path_rate:     float =         0.1
+    ):
+        """# Instantiate Convolutional Vision Transformer.
+
+        ## Args:
+            * id                (str):          Network identifier.
+            * input_shape       (Tuple[int]):   Shape of input samples (C, H, W).
+            * num_classes       (int):          Number of output logits.
+            * embed_dims        (List[int]):    Per-stage embedding dimensions.
+            * depths            (List[int]):    Per-stage number of blocks.
+            * num_heads         (List[int]):    Per-stage attention head counts.
+            * patch_sizes       (List[int]):    Per-stage conv-embedding kernel sizes.
+            * patch_strides     (List[int]):    Per-stage conv-embedding strides.
+            * patch_paddings    (List[int]):    Per-stage conv-embedding paddings.
+            * mlp_ratios        (List[float]):  Per-stage MLP expansion ratios.
+            * qkv_bias          (bool):         Whether Q/K/V projections use a bias.
+            * drop_rate         (float):        Dropout applied in MLPs and output projection.
+            * attn_drop_rate    (float):        Dropout applied to attention weights.
+            * drop_path_rate    (float):        Maximum stochastic depth rate (linear schedule).
+        """
+        super(CvT, self).__init__(network_id = id)
+
+        num_stages:     int =   len(depths)
+        for name, values in (
+            ("embed_dims",      embed_dims),
+            ("num_heads",       num_heads),
+            ("patch_sizes",     patch_sizes),
+            ("patch_strides",   patch_strides),
+            ("patch_paddings",  patch_paddings),
+            ("mlp_ratios",      mlp_ratios),
+        ):
+            if len(values) != num_stages:
+                raise ValueError(
+                    f"{name} must have length {num_stages}, got {len(values)}"
+                )
+
+        # Linear stochastic depth schedule across every block in every stage.
+        total_blocks:   int =           sum(depths)
+        if total_blocks > 1:
+            dpr:        List[float] =   [
+                                            drop_path_rate * i / (total_blocks - 1)
+                                            for i in range(total_blocks)
+                                        ]
+        else:
+            dpr =                       [0.0] * total_blocks
+
+        stages:         List[CvTStage] =    []
+        in_channels:    int =               input_shape[0]
+        cursor:         int =               0
+
+        for stage_idx in range(num_stages):
+            depth:      int =   depths[stage_idx]
+            stage:      CvTStage =  CvTStage(
+                                        in_channels =       in_channels,
+                                        embed_dim =         embed_dims[stage_idx],
+                                        depth =             depth,
+                                        num_heads =         num_heads[stage_idx],
+                                        patch_size =        patch_sizes[stage_idx],
+                                        patch_stride =      patch_strides[stage_idx],
+                                        patch_padding =     patch_paddings[stage_idx],
+                                        mlp_ratio =         mlp_ratios[stage_idx],
+                                        qkv_bias =          qkv_bias,
+                                        drop_rate =         drop_rate,
+                                        attn_drop_rate =    attn_drop_rate,
+                                        drop_path_rates =   dpr[cursor : cursor + depth]
+                                    )
+            stages.append(stage)
+
+            in_channels =   embed_dims[stage_idx]
+            cursor +=       depth
+
+        self._stages_:  ModuleList =    ModuleList(stages)
+        self._norm_:    LayerNorm =     LayerNorm(normalized_shape = embed_dims[-1])
+        self._head_:    Linear =        Linear(
+                                            in_features =   embed_dims[-1],
+                                            out_features =  num_classes
+                                        )
+
+        self._initialize_weights_()
+
+    def forward(self,
+        X:                  Tensor,
+        return_activations: bool =  False
+    ) -> Tensor:
+        """# Forward Pass Through Network.
+
+        ## Args:
+            * X                     (Tensor):   Input tensor of shape (B, C, H, W).
+            * return_activations    (bool):     Return per-stage activations alongside logits.
+
+        ## Returns:
+            * Tensor:   Logits of shape (B, num_classes). When `return_activations`
+                        is True a tuple (logits, activations) is returned instead.
+        """
+        activations:    List[Tensor] = []
+
+        for stage in self._stages_:
+            X, _, _ = stage(X)
+
+            if return_activations:
+                activations.append(X.detach())
+
+        # Global average pool over the final spatial dimensions.
+        B, C, _, _ =    X.shape
+        tokens:         Tensor =    X.flatten(2).transpose(1, 2)
+        tokens =                    self._norm_(tokens)
+        pooled:         Tensor =    tokens.mean(dim = 1)
+
+        logits:         Tensor =    self._head_(pooled)
+
+        if return_activations:
+            return logits, activations
+
+        return logits
+
+    def _initialize_weights_(self) -> None:
+        """# Initialize Weights."""
+        for m in self.modules():
+
+            if isinstance(m, Linear):
+                trunc_normal_(tensor = m.weight, std = 0.02)
+                if m.bias is not None:
+                    constant_(tensor = m.bias, val = 0)
+
+            elif isinstance(m, LayerNorm):
+                constant_(tensor = m.bias,   val = 0)
+                constant_(tensor = m.weight, val = 1)
+
+            elif isinstance(m, Conv2d):
+                trunc_normal_(tensor = m.weight, std = 0.02)
+                if m.bias is not None:
+                    constant_(tensor = m.bias, val = 0)

--- a/gradus/networks/cvt/__init__.py
+++ b/gradus/networks/cvt/__init__.py
@@ -6,6 +6,14 @@ Convolutional Vision Transformer (CvT) architectures.
 __all__ =   [
                 # Networks
                 "CvT13",
+
+                # Blocks
+                "ConvAttention",
+                "ConvEmbed",
+                "CvTBlock",
+                "CvTStage",
             ]
+
+from gradus.networks.cvt.blocks import *
 
 from gradus.networks.cvt.cvt_13 import CvT13

--- a/gradus/networks/cvt/__init__.py
+++ b/gradus/networks/cvt/__init__.py
@@ -1,0 +1,11 @@
+"""# gradus.networks.cvt
+
+Convolutional Vision Transformer (CvT) architectures.
+"""
+
+__all__ =   [
+                # Networks
+                "CvT13",
+            ]
+
+from gradus.networks.cvt.cvt_13 import CvT13

--- a/gradus/networks/cvt/blocks/__init__.py
+++ b/gradus/networks/cvt/blocks/__init__.py
@@ -1,0 +1,16 @@
+"""# gradus.networks.cvt.blocks
+
+Building blocks for the Convolutional Vision Transformer architecture.
+"""
+
+__all__ =   [
+                "ConvEmbed",
+                "ConvAttention",
+                "CvTBlock",
+                "CvTStage",
+            ]
+
+from gradus.networks.cvt.blocks.conv_embed      import ConvEmbed
+from gradus.networks.cvt.blocks.conv_attention  import ConvAttention
+from gradus.networks.cvt.blocks.cvt_block       import CvTBlock
+from gradus.networks.cvt.blocks.cvt_stage       import CvTStage

--- a/gradus/networks/cvt/blocks/__init__.py
+++ b/gradus/networks/cvt/blocks/__init__.py
@@ -4,13 +4,13 @@ Building blocks for the Convolutional Vision Transformer architecture.
 """
 
 __all__ =   [
-                "ConvEmbed",
                 "ConvAttention",
+                "ConvEmbed",
                 "CvTBlock",
                 "CvTStage",
             ]
 
-from gradus.networks.cvt.blocks.conv_embed      import ConvEmbed
 from gradus.networks.cvt.blocks.conv_attention  import ConvAttention
+from gradus.networks.cvt.blocks.conv_embed      import ConvEmbed
 from gradus.networks.cvt.blocks.cvt_block       import CvTBlock
 from gradus.networks.cvt.blocks.cvt_stage       import CvTStage

--- a/gradus/networks/cvt/blocks/conv_attention.py
+++ b/gradus/networks/cvt/blocks/conv_attention.py
@@ -1,0 +1,183 @@
+"""# gradus.networks.cvt.blocks.conv_attention
+
+Convolutional Projection Multi-Head Self-Attention block used by CvT stages.
+"""
+
+__all__ = ["ConvAttention"]
+
+from torch          import einsum, Tensor
+from torch.nn       import BatchNorm2d, Conv2d, Dropout, Linear, Module, Sequential
+from torch.nn.functional    import softmax
+
+
+class ConvAttention(Module):
+    """# Convolutional Projection Multi-Head Self-Attention.
+
+    Replaces the linear Q/K/V projections of a Transformer with
+    depth-wise separable convolutions. Operates on token tensors of
+    shape (B, H * W, C) together with the spatial dimensions (H, W).
+    """
+
+    def __init__(self,
+        dim:            int,
+        num_heads:      int,
+        kernel_size:    int =   3,
+        stride_kv:      int =   2,
+        stride_q:       int =   1,
+        padding:        int =   1,
+        attn_drop:      float = 0.0,
+        proj_drop:      float = 0.0,
+        qkv_bias:       bool =  True
+    ):
+        """# Instantiate Convolutional Attention Block.
+
+        ## Args:
+            * dim           (int):      Embedding dimension.
+            * num_heads     (int):      Number of attention heads.
+            * kernel_size   (int):      Depth-wise convolution kernel size.
+            * stride_kv     (int):      Stride used for K/V depth-wise conv.
+            * stride_q      (int):      Stride used for Q depth-wise conv.
+            * padding       (int):      Depth-wise convolution padding.
+            * attn_drop     (float):    Dropout applied to attention weights.
+            * proj_drop     (float):    Dropout applied to the output projection.
+            * qkv_bias      (bool):     Whether the Q/K/V linear projections use a bias.
+        """
+        super(ConvAttention, self).__init__()
+
+        if dim % num_heads != 0:
+            raise ValueError(
+                f"dim ({dim}) must be divisible by num_heads ({num_heads})"
+            )
+
+        self._dim_:         int =   dim
+        self._num_heads_:   int =   num_heads
+        self._head_dim_:    int =   dim // num_heads
+        self._scale_:       float = self._head_dim_ ** -0.5
+
+        # Depth-wise separable projections (DW conv + BN) for Q, K, V.
+        self._conv_proj_q_: Sequential =    self._build_conv_proj_(
+                                                dim =           dim,
+                                                kernel_size =   kernel_size,
+                                                stride =        stride_q,
+                                                padding =       padding
+                                            )
+        self._conv_proj_k_: Sequential =    self._build_conv_proj_(
+                                                dim =           dim,
+                                                kernel_size =   kernel_size,
+                                                stride =        stride_kv,
+                                                padding =       padding
+                                            )
+        self._conv_proj_v_: Sequential =    self._build_conv_proj_(
+                                                dim =           dim,
+                                                kernel_size =   kernel_size,
+                                                stride =        stride_kv,
+                                                padding =       padding
+                                            )
+
+        # Linear projections after the convolutional projection.
+        self._proj_q_:      Linear =    Linear(dim, dim, bias = qkv_bias)
+        self._proj_k_:      Linear =    Linear(dim, dim, bias = qkv_bias)
+        self._proj_v_:      Linear =    Linear(dim, dim, bias = qkv_bias)
+
+        self._attn_drop_:   Dropout =   Dropout(p = attn_drop)
+        self._proj_:        Linear =    Linear(dim, dim)
+        self._proj_drop_:   Dropout =   Dropout(p = proj_drop)
+
+    @staticmethod
+    def _build_conv_proj_(
+        dim:            int,
+        kernel_size:    int,
+        stride:         int,
+        padding:        int
+    ) -> Sequential:
+        """# Build Depth-wise Convolutional Projection.
+
+        ## Args:
+            * dim           (int):  Feature dimension.
+            * kernel_size   (int):  Convolution kernel size.
+            * stride        (int):  Convolution stride.
+            * padding       (int):  Convolution padding.
+
+        ## Returns:
+            * Sequential:   Depth-wise convolution followed by batch normalization.
+        """
+        return Sequential(
+            Conv2d(
+                in_channels =   dim,
+                out_channels =  dim,
+                kernel_size =   kernel_size,
+                stride =        stride,
+                padding =       padding,
+                groups =        dim,
+                bias =          False
+            ),
+            BatchNorm2d(num_features = dim)
+        )
+
+    def _project_(self,
+        X:      Tensor,
+        H:      int,
+        W:      int,
+        conv:   Sequential
+    ) -> Tensor:
+        """# Apply Convolutional Projection & Flatten to Tokens.
+
+        ## Args:
+            * X     (Tensor):           Input tokens of shape (B, HW, C).
+            * H     (int):              Spatial height of the input map.
+            * W     (int):              Spatial width of the input map.
+            * conv  (Sequential):       Depth-wise projection module.
+
+        ## Returns:
+            * Tensor:   Projected tokens of shape (B, H'W', C).
+        """
+        B, _, C = X.shape
+
+        # Reshape tokens to (B, C, H, W) for the depth-wise conv.
+        feature_map:    Tensor =    X.transpose(1, 2).reshape(B, C, H, W)
+        feature_map =               conv(feature_map)
+
+        # Flatten spatial dimensions back to tokens.
+        return feature_map.flatten(2).transpose(1, 2)
+
+    def forward(self,
+        X:  Tensor,
+        H:  int,
+        W:  int
+    ) -> Tensor:
+        """# Forward Pass.
+
+        ## Args:
+            * X (Tensor):   Tokens of shape (B, H * W, C).
+            * H (int):      Spatial height of the token grid.
+            * W (int):      Spatial width of the token grid.
+
+        ## Returns:
+            * Tensor:   Attention output of shape (B, H * W, C).
+        """
+        q:  Tensor =    self._project_(X = X, H = H, W = W, conv = self._conv_proj_q_)
+        k:  Tensor =    self._project_(X = X, H = H, W = W, conv = self._conv_proj_k_)
+        v:  Tensor =    self._project_(X = X, H = H, W = W, conv = self._conv_proj_v_)
+
+        q = self._proj_q_(q)
+        k = self._proj_k_(k)
+        v = self._proj_v_(v)
+
+        # Split into heads: (B, N, C) -> (B, heads, N, head_dim).
+        B, _, _ = q.shape
+        q = q.reshape(B, -1, self._num_heads_, self._head_dim_).permute(0, 2, 1, 3)
+        k = k.reshape(B, -1, self._num_heads_, self._head_dim_).permute(0, 2, 1, 3)
+        v = v.reshape(B, -1, self._num_heads_, self._head_dim_).permute(0, 2, 1, 3)
+
+        # Scaled dot-product attention.
+        attn:   Tensor =    einsum("bhqd,bhkd->bhqk", q, k) * self._scale_
+        attn =              softmax(attn, dim = -1)
+        attn =              self._attn_drop_(attn)
+
+        out:    Tensor =    einsum("bhqk,bhkd->bhqd", attn, v)
+        out =               out.permute(0, 2, 1, 3).reshape(B, -1, self._dim_)
+
+        out = self._proj_(out)
+        out = self._proj_drop_(out)
+
+        return out

--- a/gradus/networks/cvt/blocks/conv_embed.py
+++ b/gradus/networks/cvt/blocks/conv_embed.py
@@ -1,0 +1,69 @@
+"""# gradus.networks.cvt.blocks.conv_embed
+
+Convolutional Token Embedding module used by CvT stages.
+"""
+
+__all__ = ["ConvEmbed"]
+
+from typing     import Tuple
+
+from torch      import Tensor
+from torch.nn   import Conv2d, LayerNorm, Module
+
+
+class ConvEmbed(Module):
+    """# Convolutional Token Embedding.
+
+    Projects a (B, C_in, H, W) feature map into a new feature map
+    (B, embed_dim, H', W') using a strided convolution, then applies
+    layer normalization across the embedding dimension.
+    """
+
+    def __init__(self,
+        in_channels:    int,
+        embed_dim:      int,
+        kernel_size:    int,
+        stride:         int,
+        padding:        int
+    ):
+        """# Instantiate Convolutional Token Embedding.
+
+        ## Args:
+            * in_channels   (int):  Number of input channels.
+            * embed_dim     (int):  Target embedding dimension.
+            * kernel_size   (int):  Convolution kernel size.
+            * stride        (int):  Convolution stride.
+            * padding       (int):  Convolution padding.
+        """
+        super(ConvEmbed, self).__init__()
+
+        self._proj_:    Conv2d =    Conv2d(
+                                        in_channels =   in_channels,
+                                        out_channels =  embed_dim,
+                                        kernel_size =   kernel_size,
+                                        stride =        stride,
+                                        padding =       padding
+                                    )
+        self._norm_:    LayerNorm = LayerNorm(normalized_shape = embed_dim)
+
+    def forward(self,
+        X:  Tensor
+    ) -> Tuple[Tensor, int, int]:
+        """# Forward Pass.
+
+        ## Args:
+            * X (Tensor):   Input feature map of shape (B, C_in, H, W).
+
+        ## Returns:
+            * Tuple[Tensor, int, int]:  Output feature map of shape
+              (B, embed_dim, H', W') along with the new spatial size.
+        """
+        X =             self._proj_(X)
+        _, _, H, W =    X.shape
+
+        # LayerNorm operates over the channel/embedding dimension.
+        X = X.flatten(2).transpose(1, 2)
+        X = self._norm_(X)
+        X = X.transpose(1, 2).reshape(-1, X.shape[-1], H, W)
+
+        return X, H, W

--- a/gradus/networks/cvt/blocks/cvt_block.py
+++ b/gradus/networks/cvt/blocks/cvt_block.py
@@ -1,0 +1,139 @@
+"""# gradus.networks.cvt.blocks.cvt_block
+
+Single CvT Transformer block: pre-norm convolutional attention + MLP.
+"""
+
+__all__ = ["CvTBlock"]
+
+from torch      import Tensor
+from torch.nn   import Dropout, GELU, Identity, LayerNorm, Linear, Module, Sequential
+
+from gradus.networks.cvt.blocks.conv_attention  import ConvAttention
+
+
+class _DropPath(Module):
+    """# Stochastic Depth (Drop Path).
+
+    Drops the residual branch with probability `drop_prob` during training.
+    At inference it behaves as an identity transformation.
+    """
+
+    def __init__(self,
+        drop_prob:  float = 0.0
+    ):
+        super(_DropPath, self).__init__()
+        self._drop_prob_:   float = drop_prob
+
+    def forward(self,
+        X:  Tensor
+    ) -> Tensor:
+        if self._drop_prob_ == 0.0 or not self.training:
+            return X
+
+        keep_prob:  float =     1.0 - self._drop_prob_
+        shape =                 (X.shape[0],) + (1,) * (X.dim() - 1)
+        random =                X.new_empty(shape).bernoulli_(keep_prob)
+        if keep_prob > 0.0:
+            random =            random.div(keep_prob)
+        return X * random
+
+
+class _MLP(Module):
+    """# Feed-Forward MLP used inside a CvT block."""
+
+    def __init__(self,
+        dim:            int,
+        hidden_dim:     int,
+        drop:           float = 0.0
+    ):
+        super(_MLP, self).__init__()
+        self._net_: Sequential =    Sequential(
+                                        Linear(dim, hidden_dim),
+                                        GELU(),
+                                        Dropout(p = drop),
+                                        Linear(hidden_dim, dim),
+                                        Dropout(p = drop)
+                                    )
+
+    def forward(self,
+        X:  Tensor
+    ) -> Tensor:
+        return self._net_(X)
+
+
+class CvTBlock(Module):
+    """# CvT Transformer Block.
+
+    Applies convolutional multi-head self-attention followed by an MLP,
+    both wrapped by pre-norm residual connections and optional stochastic
+    depth.
+    """
+
+    def __init__(self,
+        dim:            int,
+        num_heads:      int,
+        mlp_ratio:      float = 4.0,
+        qkv_bias:       bool =  True,
+        drop:           float = 0.0,
+        attn_drop:      float = 0.0,
+        drop_path:      float = 0.0,
+        kernel_size:    int =   3,
+        stride_kv:      int =   2,
+        stride_q:       int =   1,
+        padding:        int =   1
+    ):
+        """# Instantiate CvT Block.
+
+        ## Args:
+            * dim           (int):      Embedding dimension.
+            * num_heads     (int):      Number of attention heads.
+            * mlp_ratio     (float):    Ratio of hidden MLP dim to embedding dim.
+            * qkv_bias      (bool):     Whether Q/K/V projections use a bias.
+            * drop          (float):    Dropout applied in the MLP and output projection.
+            * attn_drop     (float):    Dropout applied to attention weights.
+            * drop_path     (float):    Stochastic depth rate.
+            * kernel_size   (int):      Convolutional projection kernel size.
+            * stride_kv     (int):      Stride for K/V depth-wise convolution.
+            * stride_q      (int):      Stride for Q depth-wise convolution.
+            * padding       (int):      Convolutional projection padding.
+        """
+        super(CvTBlock, self).__init__()
+
+        self._norm1_:       LayerNorm =     LayerNorm(normalized_shape = dim)
+        self._attn_:        ConvAttention = ConvAttention(
+                                                dim =           dim,
+                                                num_heads =     num_heads,
+                                                kernel_size =   kernel_size,
+                                                stride_kv =     stride_kv,
+                                                stride_q =      stride_q,
+                                                padding =       padding,
+                                                attn_drop =     attn_drop,
+                                                proj_drop =     drop,
+                                                qkv_bias =      qkv_bias
+                                            )
+        self._drop_path_:   Module =        _DropPath(drop_prob = drop_path) if drop_path > 0.0 else Identity()
+        self._norm2_:       LayerNorm =     LayerNorm(normalized_shape = dim)
+        self._mlp_:         _MLP =          _MLP(
+                                                dim =           dim,
+                                                hidden_dim =    int(dim * mlp_ratio),
+                                                drop =          drop
+                                            )
+
+    def forward(self,
+        X:  Tensor,
+        H:  int,
+        W:  int
+    ) -> Tensor:
+        """# Forward Pass.
+
+        ## Args:
+            * X (Tensor):   Tokens of shape (B, H * W, C).
+            * H (int):      Spatial height of the token grid.
+            * W (int):      Spatial width of the token grid.
+
+        ## Returns:
+            * Tensor:   Output tokens of shape (B, H * W, C).
+        """
+        X = X + self._drop_path_(self._attn_(self._norm1_(X), H, W))
+        X = X + self._drop_path_(self._mlp_(self._norm2_(X)))
+        return X

--- a/gradus/networks/cvt/blocks/cvt_stage.py
+++ b/gradus/networks/cvt/blocks/cvt_stage.py
@@ -1,0 +1,134 @@
+"""# gradus.networks.cvt.blocks.cvt_stage
+
+One CvT stage: convolutional token embedding followed by a sequence of
+convolutional Transformer blocks.
+"""
+
+__all__ = ["CvTStage"]
+
+from typing     import List, Tuple
+
+from torch      import Tensor
+from torch.nn   import Dropout, Module, ModuleList
+
+from gradus.networks.cvt.blocks.conv_embed  import ConvEmbed
+from gradus.networks.cvt.blocks.cvt_block   import CvTBlock
+
+
+class CvTStage(Module):
+    """# CvT Stage.
+
+    Applies a convolutional token embedding to the incoming feature map and
+    then processes the resulting tokens with `depth` CvT blocks.
+    """
+
+    def __init__(self,
+        in_channels:    int,
+        embed_dim:      int,
+        depth:          int,
+        num_heads:      int,
+        patch_size:     int,
+        patch_stride:   int,
+        patch_padding:  int,
+        mlp_ratio:      float =         4.0,
+        qkv_bias:       bool =          True,
+        drop_rate:      float =         0.0,
+        attn_drop_rate: float =         0.0,
+        drop_path_rates:List[float] =   None,
+        kernel_size:    int =           3,
+        stride_kv:      int =           2,
+        stride_q:       int =           1,
+        padding:        int =           1
+    ):
+        """# Instantiate CvT Stage.
+
+        ## Args:
+            * in_channels       (int):          Number of input channels.
+            * embed_dim         (int):          Target embedding dimension.
+            * depth             (int):          Number of CvT blocks in the stage.
+            * num_heads         (int):          Number of attention heads per block.
+            * patch_size        (int):          Convolutional embedding kernel size.
+            * patch_stride      (int):          Convolutional embedding stride.
+            * patch_padding     (int):          Convolutional embedding padding.
+            * mlp_ratio         (float):        Ratio of MLP hidden dim to embed dim.
+            * qkv_bias          (bool):         Whether Q/K/V projections use a bias.
+            * drop_rate         (float):        Dropout applied after the embedding and
+                                                within MLP / output projections.
+            * attn_drop_rate    (float):        Dropout applied to attention weights.
+            * drop_path_rates   (List[float]):  Per-block stochastic depth rates; must be
+                                                of length `depth` when provided.
+            * kernel_size       (int):          Convolutional projection kernel size.
+            * stride_kv         (int):          Stride for K/V depth-wise projection.
+            * stride_q          (int):          Stride for Q depth-wise projection.
+            * padding           (int):          Convolutional projection padding.
+        """
+        super(CvTStage, self).__init__()
+
+        if drop_path_rates is None:
+            drop_path_rates = [0.0] * depth
+
+        if len(drop_path_rates) != depth:
+            raise ValueError(
+                f"drop_path_rates must have length {depth}, got {len(drop_path_rates)}"
+            )
+
+        self._patch_embed_: ConvEmbed = ConvEmbed(
+                                            in_channels =   in_channels,
+                                            embed_dim =     embed_dim,
+                                            kernel_size =   patch_size,
+                                            stride =        patch_stride,
+                                            padding =       patch_padding
+                                        )
+        self._pos_drop_:    Dropout =   Dropout(p = drop_rate)
+
+        self._blocks_:      ModuleList = ModuleList(
+                                            [
+                                                CvTBlock(
+                                                    dim =           embed_dim,
+                                                    num_heads =     num_heads,
+                                                    mlp_ratio =     mlp_ratio,
+                                                    qkv_bias =      qkv_bias,
+                                                    drop =          drop_rate,
+                                                    attn_drop =     attn_drop_rate,
+                                                    drop_path =     drop_path_rates[i],
+                                                    kernel_size =   kernel_size,
+                                                    stride_kv =     stride_kv,
+                                                    stride_q =      stride_q,
+                                                    padding =       padding
+                                                )
+                                                for i in range(depth)
+                                            ]
+                                        )
+
+        self._embed_dim_:   int =       embed_dim
+
+    @property
+    def embed_dim(self) -> int:
+        """# Stage Output Embedding Dimension."""
+        return self._embed_dim_
+
+    def forward(self,
+        X:  Tensor
+    ) -> Tuple[Tensor, int, int]:
+        """# Forward Pass Through CvT Stage.
+
+        ## Args:
+            * X (Tensor):   Feature map of shape (B, C_in, H, W).
+
+        ## Returns:
+            * Tuple[Tensor, int, int]:  Feature map of shape (B, embed_dim, H', W')
+              together with the output spatial dimensions (H', W').
+        """
+        X, H, W =   self._patch_embed_(X)
+        B, C, _, _ = X.shape
+
+        # Flatten to tokens for attention blocks.
+        X = X.flatten(2).transpose(1, 2)
+        X = self._pos_drop_(X)
+
+        for block in self._blocks_:
+            X = block(X, H, W)
+
+        # Restore spatial layout for the next stage.
+        X = X.transpose(1, 2).reshape(B, C, H, W)
+        return X, H, W

--- a/gradus/networks/cvt/cvt_13/__args__.py
+++ b/gradus/networks/cvt/cvt_13/__args__.py
@@ -1,0 +1,19 @@
+"""# gradus.networks.cvt.cvt_13.args
+
+Argument definitions & parsing for the CvT-13 neural network.
+"""
+
+__all__ = ["CvT13Config"]
+
+from gradus.configuration   import NetworkConfig
+
+
+class CvT13Config(NetworkConfig):
+    """# CvT-13 Network Configuration"""
+
+    def __init__(self):
+        """# Instantiate CvT-13 Network Configuration."""
+        super(CvT13Config, self).__init__(
+            name =  "cvt-13",
+            help =  """Convolutional Vision Transformer with 13 transformer blocks."""
+        )

--- a/gradus/networks/cvt/cvt_13/__base__.py
+++ b/gradus/networks/cvt/cvt_13/__base__.py
@@ -1,0 +1,68 @@
+"""# gradus.networks.cvt.cvt_13.base
+
+CvT-13 neural network implementation.
+"""
+
+__all__ = ["CvT13"]
+
+from typing     import Tuple
+
+from gradus.networks.cvt.__base__               import CvT
+from gradus.networks.cvt.cvt_13.__args__        import CvT13Config
+from gradus.registration                        import register_network
+
+
+@register_network(
+    id =        "cvt-13",
+    config =    CvT13Config,
+    tags =      ["transformer", "convolutional", "vision-transformer", "13-blocks"]
+)
+class CvT13(CvT):
+    """# 13-Block Convolutional Vision Transformer.
+
+    Follows the CvT-13 configuration from "CvT: Introducing Convolutions to
+    Vision Transformers" (Wu et al., 2021): three hierarchical stages with
+    (1, 2, 10) transformer blocks and embedding dimensions (64, 192, 384).
+    """
+
+    def __init__(self,
+        input_shape:    Tuple[int, ...],
+        num_classes:    int,
+        drop_rate:      float = 0.0,
+        attn_drop_rate: float = 0.0,
+        drop_path_rate: float = 0.1,
+        **kwargs
+    ):
+        """# Instantiate CvT-13 Neural Network.
+
+        ## Args:
+            * input_shape       (Tuple[int]):   Shape of input samples (C, H, W).
+            * num_classes       (int):          Number of output logits.
+            * drop_rate         (float):        Dropout applied in MLPs and output projections.
+            * attn_drop_rate    (float):        Dropout applied to attention weights.
+            * drop_path_rate    (float):        Maximum stochastic depth rate.
+        """
+        # For small inputs (e.g. CIFAR-10) shrink the stem stride so we do not
+        # collapse spatial resolution to zero before the attention stages run.
+        small_stem:     bool =  input_shape[1] <= 64
+
+        patch_sizes =       [7,         3,      3]
+        patch_strides =     [2 if small_stem else 4,    2,      2]
+        patch_paddings =    [2,         1,      1]
+
+        super(CvT13, self).__init__(
+            id =                "cvt-13",
+            input_shape =       input_shape,
+            num_classes =       num_classes,
+            embed_dims =        [64,        192,    384],
+            depths =            [1,         2,      10],
+            num_heads =         [1,         3,      6],
+            patch_sizes =       patch_sizes,
+            patch_strides =     patch_strides,
+            patch_paddings =    patch_paddings,
+            mlp_ratios =        [4.0,       4.0,    4.0],
+            qkv_bias =          True,
+            drop_rate =         drop_rate,
+            attn_drop_rate =    attn_drop_rate,
+            drop_path_rate =    drop_path_rate
+        )

--- a/gradus/networks/cvt/cvt_13/__init__.py
+++ b/gradus/networks/cvt/cvt_13/__init__.py
@@ -1,0 +1,8 @@
+"""# gradus.networks.cvt.cvt_13
+
+Convolutional Vision Transformer with 13 transformer blocks.
+"""
+
+__all__ = ["CvT13"]
+
+from gradus.networks.cvt.cvt_13.__base__    import CvT13


### PR DESCRIPTION
## Summary
- Adds the missing `gradus/networks/cvt/` package and the `from gradus.networks.cvt import *` line in `gradus/networks/__init__.py`. Without this, `@register_network(id='cvt-13')` never fired, so argparse rejected `network_id='cvt-13'` — the root cause of the repeated SLURM failures under `logs/gradus-baseline-cvt13_*`.
- Flips DSI from "fraction saved" (`1 - processed/(max*epochs)`) to "sum of batches used per epoch / max batches per epoch", matching the stated definition. Old formula returned 0 for every baseline run.
- Exposes `batches_per_epoch`, `total_batches_processed`, and `max_batches_per_epoch` in both the verbose JSON record and the master CSV so the DSI value is manually auditable.

## Test plan
- [ ] Pull this branch on the LONI node and re-submit `experiments/baseline/baseline_cvt13.sh`; confirm argparse accepts `cvt-13` and training proceeds.
- [ ] Inspect a new verbose record JSON and confirm `batches_per_epoch` is a list equal in length to `epochs`, and that `dsi == total_batches_processed / max_batches_per_epoch`.
- [ ] Confirm master CSV gains the two new columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)